### PR TITLE
Added audio normalization as a check

### DIFF
--- a/backend/src/programs/services/processing/FileChecker.py
+++ b/backend/src/programs/services/processing/FileChecker.py
@@ -88,7 +88,7 @@ class FileChecker:
     def check_normalization_clipping(self):
         normalization_data = read_loudnorm_data()
 
-        #Set a 3dB tolerance for volume
+        #Set a 2dB tolerance for volume
         measured_i = normalization_data["input_i"]
         target_i = -16.0
         tolerance_i = 2.0
@@ -102,7 +102,7 @@ class FileChecker:
             self.warnings.append(FileDynamicRange(measured_lra, 11.0))
         
         #Set true peak normalization
-        if normalization_data["input_tp"] >= 0.0:
+        if normalization_data["input_tp"] >= -0.2:
             self.problems.append(FileHasClipping)
 
         return normalization_data

--- a/backend/src/programs/services/processing/FileChecker.py
+++ b/backend/src/programs/services/processing/FileChecker.py
@@ -24,7 +24,7 @@ class FileChecker:
         self.warnings = []
 
     def run_checks(self):
-        default_params = ["-ar", self.min_sample_rate, "-ac", 2]  # 2 = number of channels
+        default_params = ["-ar", self.min_sample_rate, "-ac", '2']  # 2 = number of channels
 
         tempo = self.check_duration(float(self.info['duration']) / 60)
         self.check_sample_rate(self.info['sample_rate'])
@@ -34,6 +34,7 @@ class FileChecker:
             raise IrrecoverableProblemsException("There are serious problems with the file and it can't be exported.")
 
         if self.do_normalization:
+            print("\t\t* Applying 2 pass loudnorm...")
             loudnorm_list = self.build_loudnorm_list(self.read_loudnorm_data())
             loudnorm_list[-1] += "," + str(tempo)
             return default_params + loudnorm_list
@@ -100,7 +101,7 @@ class FileChecker:
             return measured_duration / closest_duration
 
         elif closest_duration < measured_duration <= closest_duration * 1.03:  # If we're here, it's within the 3% range.
-            self.problems.append(
+            self.warnings.append(
                 FileDurationAboveFixed(measured_duration, closest_duration)
             )
             return measured_duration / closest_duration

--- a/backend/src/programs/services/processing/Messages.py
+++ b/backend/src/programs/services/processing/Messages.py
@@ -58,7 +58,7 @@ class FileDurationBelowLimit(Message):
 class FileDurationAboveFixed(Message):
     def message(self):
         return "O ficheiro da emissão tinha {0} minutos, estando acima dos " \
-               "{1} minutos, mas foi ajustada automaticamente e está pronta para ir " \
+               "{1} minutos, mas foi ajustado automaticamente e está pronta para ir " \
                "para o ar. Não precisas de fazer mais nada.".format(self.measured_value,
                                                                     self.recommended_value)
 
@@ -67,7 +67,7 @@ class FileHasClipping(Message):
         return "O ficheiro da emissão possuia clipping, ou seja, um pico acima do volume " \
                 "máximo da transmissão. Assegure-se que quando faz a gravação, e durante " \
                 "a mistura, não excede o volume máximo (0 dB). Por favor, remistura o teu " \
-                "ficheiro de forma a que não existam estes picos e envia de novo."
+                "ficheiro de forma a baixar ligeiramente o volume nos picos e envia de novo."
 
 class FileNotNormalized(Message):
     def message(self):
@@ -78,7 +78,8 @@ class FileNotNormalized(Message):
 
 class FileDynamicRange(Message):
     def message(self):
-        return "O ficheiro de emissão tinha uma dinâmica de som de {0} dB (variação de volume " \
-                "entre partes altas e silenciosas) que é superior a {1} dB indicado para a emissão, " \
-                "mas foi ajustada automaticamente e está pronto a ir ao ar. Não precisas de fazer " \
+        return "O ficheiro de emissão tinha uma variação de volume entre partes altas e " \
+                "silenciosas muito grande (dinâmica de som). A dinâmica de {0} dB LU é maior " \
+                "do que os {1} dB LU indicados para a emissão, mas o som foi comprimido " \
+                "automaticamente e está pronto a ir ao ar. Não precisas de fazer " \
                 "mais nada.".format(self.measured_value, self.recommended_value)

--- a/backend/src/programs/services/processing/Messages.py
+++ b/backend/src/programs/services/processing/Messages.py
@@ -61,3 +61,24 @@ class FileDurationAboveFixed(Message):
                "{1} minutos, mas foi ajustada automaticamente e está pronta para ir " \
                "para o ar. Não precisas de fazer mais nada.".format(self.measured_value,
                                                                     self.recommended_value)
+
+class FileHasClipping(Message):
+    def message(self):
+        return "O ficheiro da emissão possuia clipping, ou seja, um pico acima do volume " \
+                "máximo da transmissão. Assegure-se que quando faz a gravação, e durante " \
+                "a mistura, não excede o volume máximo (0 dB). Por favor, remistura o teu " \
+                "ficheiro de forma a que não existam estes picos e envia de novo."
+
+class FileNotNormalized(Message):
+    def message(self):
+        return "O ficheiro da emissão tinha um volume de som medido de {0} dB LUFS, que se " \
+                "afasta do volume de som indicado para emissão, que é {1} dB LUFS, mas foi " \
+                "ajustado automaticamente e está pronto a ir ao ar. Não precisas de fazer " \
+                "mais nada.".format(self.measured_value, self.recommended_value)
+
+class FileDynamicRange(Message):
+    def message(self):
+        return "O ficheiro de emissão tinha uma dinâmica de som de {0} dB (variação de volume " \
+                "entre partes altas e silenciosas) que é superior a {1} dB indicado para a emissão, " \
+                "mas foi ajustada automaticamente e está pronto a ir ao ar. Não precisas de fazer " \
+                "mais nada.".format(self.measured_value, self.recommended_value)


### PR DESCRIPTION
I propose we use the normalization parameters to do some checks on the files submitted by the users. This will enable them to learn if their audio is clipping; if they have mastered their sound too low or too high, or if they have too much variation in the volume of their audio. In the future, this will also allow us to skip processing files that have a reasonable normalization as submitted, enabling us to save computing cycles.